### PR TITLE
update(teaching): update capture_the_flag task to include pwning

### DIFF
--- a/Teaching/Miscellaneous/capture_the_flag.md
+++ b/Teaching/Miscellaneous/capture_the_flag.md
@@ -35,9 +35,13 @@ presentation should cover the following topics:
    for solving Reverse Engineering challenges
 1. Try out one Reverse Engineering and one Pwning challenge from the internet,
    and describe your solutions in detail. Document your CTF writeups in markdown
-   files (`.md`). You are encouraged to create a github repo for this. You can
-   choose the challenges, but try to choose interesting, or at least non-trivial
-   ones
+   files (`.md`). You are encouraged to create a github repo for this
+
+> [!NOTE] 
+> We know that this task involves learning about many concepts, so we do
+> not expect you to become masters in just a couple of days. We want to see
+> what you've explored, the effort you've put into this, and how you overcame
+> any hurdles.
 
 Please create a presentation, either using PPT or preferably an Open Source
 tool such as [RevealJS](https://revealjs.com/). The interviewee needs to keep

--- a/Teaching/Miscellaneous/capture_the_flag.md
+++ b/Teaching/Miscellaneous/capture_the_flag.md
@@ -1,24 +1,51 @@
 # Introduction to Capture the Flag (CTF) competitions
 
-## Background:
-Capture the Flag (CTF) is a type of cybersecurity competition that involves a series of challenges designed to test the skills and knowledge of participants in various areas of cybersecurity. These competitions simulate real-world cyber attack and defense scenarios, providing participants with hands-on experience in a safe and controlled environment. CTF competitions are becoming increasingly popular among cybersecurity professionals, students, and enthusiasts as they offer an exciting and challenging way to learn new skills and showcase existing ones.
+## Background: Capture the Flag (CTF) is a type of cybersecurity competition
+that involves a series of challenges designed to test the skills and knowledge
+of participants in various areas of cybersecurity. These competitions simulate
+real-world cyber attack and defense scenarios, providing participants with
+hands-on experience in a safe and controlled environment. CTF competitions are
+becoming increasingly popular among cybersecurity professionals, students, and
+enthusiasts as they offer an exciting and challenging way to learn new skills
+and showcase existing ones.
 
 ## What you need to do:
 
-As part of this task, you will need to create a simple presentation that introduces the concept of Capture the Flag (CTF) competitions to a group of beginners. Your presentation should cover the following topics:
+As part of this task, you will need to create a simple presentation that
+introduces the concept of Capture the Flag (CTF) competitions and basic
+principles of reverse engineering and pwning to a group of beginners. Your
+presentation should cover the following topics:
 
 1. Introduction to cybersecurity and hacking
-2. Briefly explain the basics of cybersecurity and the concept of hacking
-3. Describe different types of cyber threats and their impact on organizations
-4. Overview of Capture the Flag (CTF) competitions
-5. Explain what CTF competitions are and how they work
-6. Briefly describe about different types of challenges that participants may encounter in CTF competitions
-7. Describe in detail about the Reverse Engineering type of challenges
-8. Common tools and techniques used in CTF competitions
-9. Describe some of the common tools and techniques that participants may use for solving Reverse Engineering challenges
-10. Try to solve a Reverse Engineering challenge from the internet using the techniques that you have learnt and describe the process
+1. Briefly explain the basics of cybersecurity and the concept of hacking
+1. Briefly describe different types of cyber threats and their impact on organizations
+1. Overview of Capture the Flag (CTF) competitions (jeopardy format)
+1. Explain what CTF competitions are and how they work
+1. Briefly describe about different types of challenges that participants may
+   encounter in CTF competitions
+1. Common tools and techniques used in CTF competitions
+1. Describe in detail about the Reverse Engineering type of challenges. Include at least the following
+    - What are Reverse Engineering challenges?
+    - What are the tools we used to solve such challenges?
+    - (Optional) Discuss Python and Rust reverse engineering challenges and techniques as well
+1. Describe in detail about Pwning challenges. Include at least the following
+    - What is pwning?
+    - What are the common vulnerabilities exploited to pwn a system (binary exploitation)? 
+    - (Optional) Discuss shellcodes
+   for solving Reverse Engineering challenges
+1. Try out one Reverse Engineering and one Pwning challenge from the internet,
+   and describe your solutions in detail. Document your CTF writeups in markdown
+   files (`.md`). You are encouraged to create a github repo for this. You can
+   choose the challenges, but try to choose interesting, or at least non-trivial
+   ones
 
-Please create a presentation, either using PPT or preferably an Open Source tool such as [RevealJS](https://revealjs.com/). The interviewee needs to keep in mind that the crowd he will be presenting to, will have mixed people of different knowledge levels, so it is advised that to keep the content balanced for all. Keep it short, to less than 20 slides or so, and you could include images, screenshots from commands run, and short snippets of code, to keep the audience interested.
+Please create a presentation, either using PPT or preferably an Open Source
+tool such as [RevealJS](https://revealjs.com/). The interviewee needs to keep
+in mind that the crowd he will be presenting to, will have mixed people of
+different knowledge levels, so it is advised that to keep the content balanced
+for all. Keep it short, to less than 20 slides or so, and you could include
+images, screenshots from commands run, and short snippets of code, to keep the
+audience interested.
 
 ## Some resources:
 
@@ -27,15 +54,36 @@ Please create a presentation, either using PPT or preferably an Open Source tool
 - [CTFtime](https://ctftime.org/)
 - [TryHackMe](https://tryhackme.com/)
 - [HackTheBox](https://www.hackthebox.eu/)
+- [pwnable.tw: pwning challenges](https://pwnable.tw/challenge/)
+- [ir0nstone's notes](https://ir0nstone.gitbook.io/notes)
+- [KOSSCTF 2025: CTF Workshop by KOSS](https://github.com/kossiitkgp/KossCTF-2025)
 
 ## Learning from the task:
 
-This task is designed to introduce beginners to the concept of Capture the Flag (CTF) competitions and provide them with an overview of the skills and knowledge required to participate in such competitions. By completing this task, you will:
+This task is designed to introduce beginners to the concept of Capture the Flag
+(CTF) competitions and provide them with an overview of the skills and
+knowledge required to participate in such competitions. It also intends to
+introduce them to concepts of Reverse Engineering and Binary Exploitation. By
+completing this task, you will:
 
 - Gain an understanding of the basics of cybersecurity and hacking
-- Learn about the different types of challenges that are encountered in CTF competitions
+- Learn about the different types of challenges that are encountered in CTF
+competitions
 - Discover the common tools and techniques used in CTF competitions
+- Learn in detail about C/C++ Binaries and their vulnerabilities
+- Practice understanding complex code
 - Learn strategies for succeeding in CTF competitions
 - Explore resources for learning and practicing CTF skills
 
-Note that, don't get lost in the theoretical sea, there are infinite topics in CTFs and Cyber security which are impossible to know, so you should use the rule of thumb to judiciously use your time to maintain a balance of theoretical understanding and practical implementation. We are more curious about your thinking ability and practical utility than the final result. So, don't worry if you are not able to complete the task, just try to do as much as you can and try to learn from the task.
+> [!WARNING]
+> Note that, don't get lost in the theoretical sea, there are infinite topics in
+> CTFs and Cyber security which are impossible to know, so you should use the
+> rule of thumb to judiciously use your time to maintain a balance of theoretical
+> understanding and practical implementation. We are more curious about your
+> thinking ability and practical utility than the final result. So, don't worry
+> if you are not able to complete the task, just try to do as much as you can and
+> try to learn from the task.
+
+### Further Reading
+
+- [The FLARE On Challenge: real world oriented rev](https://flare-on.com/)

--- a/Teaching/Miscellaneous/capture_the_flag.md
+++ b/Teaching/Miscellaneous/capture_the_flag.md
@@ -1,6 +1,7 @@
 # Introduction to Capture the Flag (CTF) competitions
 
-## Background: Capture the Flag (CTF) is a type of cybersecurity competition
+## Background: 
+Capture the Flag (CTF) is a type of cybersecurity competition
 that involves a series of challenges designed to test the skills and knowledge
 of participants in various areas of cybersecurity. These competitions simulate
 real-world cyber attack and defense scenarios, providing participants with
@@ -26,13 +27,12 @@ presentation should cover the following topics:
 1. Common tools and techniques used in CTF competitions
 1. Describe in detail about the Reverse Engineering type of challenges. Include at least the following
     - What are Reverse Engineering challenges?
-    - What are the tools we used to solve such challenges?
+    - What are the tools used to solve such challenges?
     - (Optional) Discuss Python and Rust reverse engineering challenges and techniques as well
 1. Describe in detail about Pwning challenges. Include at least the following
     - What is pwning?
     - What are the common vulnerabilities exploited to pwn a system (binary exploitation)? 
-    - (Optional) Discuss shellcodes
-   for solving Reverse Engineering challenges
+    - (Optional) Discuss shellcodes for solving Reverse Engineering challenges
 1. Try out one Reverse Engineering and one Pwning challenge from the internet,
    and describe your solutions in detail. Document your CTF writeups in markdown
    files (`.md`). You are encouraged to create a github repo for this


### PR DESCRIPTION
why this change? with the ctf workshop done this year and the (perceived) growing interest in cybersecurity this challenge needed updating to be slightly more challenging. the ctf workshop essentially already covered the contents of the task, which is why updating it with something not covered in the workshop is important

with this update I try to get them to explore rev and binary exploitation in more detail than earlier, and intend to challenge them with more involved concepts like shellcodes

cc: #3 